### PR TITLE
Fixed issue with versioning and permalinks

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -549,7 +549,7 @@ router.post('/save_kb', common.restrict, function(req, res){
 		keywords = '';
 	}
 
-    db.kb.count({'kb_permalink': req.body.frm_kb_permalink, $not: {_id: common.getId(req.body.frm_kb_id)}}, function (err, kb){
+    db.kb.count({'kb_permalink': req.body.frm_kb_permalink, $not: {_id: common.getId(req.body.frm_kb_id)}, kb_versioned_doc: {$ne: true}}, function (err, kb){
 		if(kb > 0 && req.body.frm_kb_permalink !== ''){
 			// permalink exits
 			req.session.message = req.i18n.__('Permalink already exists. Pick a new one.');


### PR DESCRIPTION
When turning on versioning when you already have articles it always results in saying the permalink already exists when you try to edit an article more than one time. 
This fixes that. 