### PR TITLE
Docker Alpine base image and bind fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+node_modules/
 data/
 .*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:7
+FROM alpine:3.5
+
+RUN apk add --update nodejs
 
 WORKDIR /var/openKB
 
@@ -14,5 +16,4 @@ RUN npm install
 VOLUME /var/openKB/data
 
 EXPOSE 4444
-
-ENTRYPOINT node app.js
+ENTRYPOINT ["npm", "start"]

--- a/app.js
+++ b/app.js
@@ -176,7 +176,7 @@ handlebars = handlebars.create({
 
 app.enable('trust proxy');
 app.set('port', process.env.PORT || 4444);
-app.set('bind', process.env.BIND || '127.0.0.1');
+app.set('bind', process.env.BIND || '0.0.0.0');
 app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: false}));


### PR DESCRIPTION
Fixed binding so node listens on the containers public ip addresses.

Changed docker base image and thereby reduced image size to ~95.9 MB from ~725 MB.