### PR TITLE
Redirect issue after successful login

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1046,7 +1046,7 @@ router.post('/login_action', function (req, res){
                     res.redirect(req.app_context + '/');
                 }else{
                     var url_parts = url.parse(req.body.frm_referring_url, true);
-                    if(url_parts.pathname !== '/setup' && url_parts.pathname !== '/login'){
+                    if(url_parts.pathname !== '/setup' && url_parts.pathname !== req.app_context + '/login'){
                         res.redirect(req.body.frm_referring_url);
                     }else{
                         res.redirect(req.app_context + '/');


### PR DESCRIPTION
This happens if you set app context config. The referrer which becomes the url_parts.pathname will have something "/wiki/login" therefore will redirect to /login even if you have valid creds.