### PR TITLE
Fix #177

### DIFF
--- a/public/javascripts/openKB.js
+++ b/public/javascripts/openKB.js
@@ -351,7 +351,7 @@ $(document).ready(function(){
 
     // applies an article filter
     $('#btn_articles_filter').click(function(){
-        window.location.href = $('#app_context').val() + '/articles/' + $('#article_filter').val();
+        window.location.href = $('#app_context').val() + '/articles/' + encodeURIComponent($('#article_filter').val());
     });
 
     // resets the article filter


### PR DESCRIPTION
Fix bug that the filter keywords contains raw `/` character will lead to url path error with `encodeURIComponent()`