### PR TITLE
fix(locales): missing comma

### DIFF
--- a/locales/tr.js
+++ b/locales/tr.js
@@ -66,7 +66,7 @@
 	"Whether to show article meta data including published date, last updated date, author etc": "Yayınlanan tarih, son güncellenen tarihi, yazar falan falan makale meta verilerinde dahil olması gösterme",
 	"Show author email": "Yazarın e-postasını göster",
 	"Controls whether the authors email address is displayed in the meta. Requires 'Show article meta data' to be true": "Yazarın e-posta adresinin meta içinde görüntülenip görüntülenmediğini kontrol eder. 'Makale meta verilerini göster' gerçek olmasını gerektirir",
-	"Article links open new page": "Makale bağlantıları yeni sayfa açar"
+	"Article links open new page": "Makale bağlantıları yeni sayfa açar",
 	"Controls whether links within articles open a new page (tab)": "Makaleler içindeki bağlantıları yeni bir sayfa açıp açmadığını kontrol eder (sekme)",
 	"Add header anchors": "Başlık çapaları ekle",
 	"Whether to add HTML anchors to all heading tags for linking within articles or direct linking from other articles": "Makaleler arasında bağlantı kurmak için tüm başlık etiketlerine veya diğer makalelerden doğrudan bağlanmak için HTML çapa ekleyip eklemediğini",


### PR DESCRIPTION
This fixes the current issue:

```
unable to parse locales from file (maybe /home/jeremie/workspace/openKB/locales/tr.js is empty or invalid .js?):  SyntaxError: Unexpected string in JSON at position 5001
    at module.exports.parse (<anonymous>)
    at module.exports.readFile (/home/jeremie/workspace/openKB/node_modules/i18n-2/i18n.js:377:24)
    at /home/jeremie/workspace/openKB/node_modules/i18n-2/i18n.js:60:9
    at Array.forEach (native)
    at module.exports (/home/jeremie/workspace/openKB/node_modules/i18n-2/i18n.js:59:15)
    at Object.<anonymous> (/home/jeremie/workspace/openKB/app.js:28:12)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
```