### PR TITLE
refactor auth mechanism into plugin structure

### DIFF
--- a/app.js
+++ b/app.js
@@ -256,6 +256,8 @@ app.use(function (req, res, next){
     req.i18n = i18n;
     req.app_context = app_context;
     req.i18n.setLocaleFromCookie();
+    req.common = common;
+    req.config = config;
 	next();
 });
 

--- a/config/config.json
+++ b/config/config.json
@@ -15,6 +15,7 @@
         "show_featured_in_article": false,
         "featured_articles_count": "4",
         "password_protect": false,
+        "auth_provider": "db",
         "show_kb_meta": true,
         "suggest_allowed": true,
         "show_author_email": true,

--- a/plugins/auth/db/db.js
+++ b/plugins/auth/db/db.js
@@ -1,0 +1,100 @@
+exports.route = function(router) {
+  // setup form is shown when there are no users setup in the DB
+  router.get('/setup', function (req, res){
+    var db = req.app.db;
+    db.users.count({}, function (err, user_count){
+        // dont allow the user to "re-setup" if a user exists.
+        // set needs_setup to false as a user exists
+        req.session.needs_setup = false;
+        if(user_count === 0){
+            res.render('setup', {
+                title: 'Setup',
+                config: req.config,
+                message: req.common.clear_session_value(req.session, 'message'),
+                message_type: req.common.clear_session_value(req.session, 'message_type'),
+                show_footer: 'show_footer',
+                helpers: req.handlebars
+            });
+        }else{
+            res.redirect(req.app_context + '/login');
+        }
+    });
+  });
+
+  // login the user and check the password
+  router.post('/login_action', function (req, res){
+    var db = req.app.db;
+    var bcrypt = req.bcrypt;
+    var url = require('url');
+
+    db.users.findOne({user_email: req.body.email}, function (err, user){
+        // check if user exists with that email
+        if(user === undefined || user === null){
+            req.session.message = req.i18n.__('A user with that email does not exist.');
+            req.session.message_type = 'danger';
+            res.redirect(req.app_context + '/login');
+        }else{
+            // we have a user under that email so we compare the password
+            if(bcrypt.compareSync(req.body.password, user.user_password) === true){
+                req.session.user = req.body.email;
+                req.session.users_name = user.users_name;
+                req.session.user_id = user._id.toString();
+                req.session.is_admin = user.is_admin;
+                if(req.body.frm_referring_url === undefined || req.body.frm_referring_url === ''){
+                    res.redirect(req.app_context + '/');
+                }else{
+                    var url_parts = url.parse(req.body.frm_referring_url, true);
+                    if(url_parts.pathname !== '/setup' && url_parts.pathname !== req.app_context + '/login'){
+                        res.redirect(req.body.frm_referring_url);
+                    }else{
+                        res.redirect(req.app_context + '/');
+                    }
+                }
+            }else{
+                // password is not correct
+                req.session.message = req.i18n.__('Access denied. Check password and try again.');
+                req.session.message_type = 'danger';
+                res.redirect(req.app_context + '/login');
+            }
+        }
+    });
+  });
+}
+
+exports.logout = function(req, res) {
+  res.redirect(req.app_context + '/');
+};
+
+exports.login = function(req, res) {
+  var db = req.app.db;
+    // set the template
+    req.common.setTemplateDir('admin', req);
+
+    db.users.count({}, function (err, user_count){
+      // we check for a user. If one exists, redirect to login form otherwise setup
+      if(user_count > 0){
+          // set needs_setup to false as a user exists
+          req.session.needs_setup = false;
+
+          // set the referring url
+          var referringUrl = req.header('Referer');
+          if(typeof req.session.refer_url !== 'undefined' && req.session.refer_url !== ''){
+              referringUrl = req.session.refer_url;
+          }
+
+          res.render('login', {
+              title: 'Login',
+              referring_url: referringUrl,
+              config: req.config,
+              message: req.common.clear_session_value(req.session, 'message'),
+              message_type: req.common.clear_session_value(req.session, 'message_type'),
+              show_footer: 'show_footer',
+              helpers: req.handlebars
+          });
+      }else{
+          // if there are no users set the "needs_setup" session
+          req.session.needs_setup = true;
+          res.redirect(req.app_context + '/setup');
+      }
+  });
+}

--- a/plugins/loader.js
+++ b/plugins/loader.js
@@ -1,0 +1,3 @@
+exports.load = function(pluginType, pluginName) {
+  return require('./' + pluginType + '/' + pluginName + '/' + pluginName);
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,6 +9,9 @@ var mime = require('mime-types');
 var lunr = require('lunr');
 var config = common.read_config();
 
+var authProvider = require('../plugins/loader').load('auth', config.settings.auth_provider);
+authProvider.route(router);
+
 var appDir = path.dirname(require('require-main-filename')());
 
 // The homepage of the site
@@ -705,7 +708,8 @@ router.get('/logout', function (req, res){
     req.session.pw_validated = null;
     req.session.message = null;
     req.session.message_type = null;
-    res.redirect(req.app_context + '/');
+
+    authProvider.logout(req, res);
 });
 
 // users
@@ -958,60 +962,8 @@ router.post('/user_update', common.restrict, function (req, res){
 });
 
 // login form
-router.get('/login', function (req, res){
-    var db = req.app.db;
-    // set the template
-    common.setTemplateDir('admin', req);
-
-    db.users.count({}, function (err, user_count){
-        // we check for a user. If one exists, redirect to login form otherwise setup
-        if(user_count > 0){
-            // set needs_setup to false as a user exists
-            req.session.needs_setup = false;
-
-            // set the referring url
-            var referringUrl = req.header('Referer');
-            if(typeof req.session.refer_url !== 'undefined' && req.session.refer_url !== ''){
-                referringUrl = req.session.refer_url;
-            }
-
-            res.render('login', {
-                title: 'Login',
-                referring_url: referringUrl,
-                config: config,
-                message: common.clear_session_value(req.session, 'message'),
-                message_type: common.clear_session_value(req.session, 'message_type'),
-                show_footer: 'show_footer',
-                helpers: req.handlebars
-            });
-        }else{
-            // if there are no users set the "needs_setup" session
-            req.session.needs_setup = true;
-            res.redirect(req.app_context + '/setup');
-        }
-    });
-});
-
-// setup form is shown when there are no users setup in the DB
-router.get('/setup', function (req, res){
-    var db = req.app.db;
-    db.users.count({}, function (err, user_count){
-        // dont allow the user to "re-setup" if a user exists.
-        // set needs_setup to false as a user exists
-        req.session.needs_setup = false;
-        if(user_count === 0){
-            res.render('setup', {
-                title: 'Setup',
-                config: config,
-                message: common.clear_session_value(req.session, 'message'),
-                message_type: common.clear_session_value(req.session, 'message_type'),
-                show_footer: 'show_footer',
-                helpers: req.handlebars
-            });
-        }else{
-            res.redirect(req.app_context + '/login');
-        }
-    });
+router.get('/login', function (req, res) {
+    authProvider.login(req, res);
 });
 
 // Loops files on the disk, checks for their existance in any KB articles and removes non used files.
@@ -1046,45 +998,6 @@ router.get('/file_cleanup', common.restrict, function (req, res){
         req.session.message = req.i18n.__('All unused files have been removed');
         req.session.message_type = 'success';
         res.redirect(req.app_context + req.header('Referer'));
-    });
-});
-
-// login the user and check the password
-router.post('/login_action', function (req, res){
-    var db = req.app.db;
-    var bcrypt = req.bcrypt;
-    var url = require('url');
-
-    db.users.findOne({user_email: req.body.email}, function (err, user){
-        // check if user exists with that email
-        if(user === undefined || user === null){
-            req.session.message = req.i18n.__('A user with that email does not exist.');
-            req.session.message_type = 'danger';
-            res.redirect(req.app_context + '/login');
-        }else{
-            // we have a user under that email so we compare the password
-            if(bcrypt.compareSync(req.body.password, user.user_password) === true){
-                req.session.user = req.body.email;
-                req.session.users_name = user.users_name;
-                req.session.user_id = user._id.toString();
-                req.session.is_admin = user.is_admin;
-                if(req.body.frm_referring_url === undefined || req.body.frm_referring_url === ''){
-                    res.redirect(req.app_context + '/');
-                }else{
-                    var url_parts = url.parse(req.body.frm_referring_url, true);
-                    if(url_parts.pathname !== '/setup' && url_parts.pathname !== req.app_context + '/login'){
-                        res.redirect(req.body.frm_referring_url);
-                    }else{
-                        res.redirect(req.app_context + '/');
-                    }
-                }
-            }else{
-                // password is not correct
-                req.session.message = req.i18n.__('Access denied. Check password and try again.');
-                req.session.message_type = 'danger';
-                res.redirect(req.app_context + '/login');
-            }
-        }
     });
 });
 


### PR DESCRIPTION
Hello,

I am performing some integration of OpenKB into our internal authentication systems. As part of this work I needed to refactor some of the login procedures so that I could insert my own login code.

After seeing #72, #144, and #248, I decided to implement my integration in such a way that might be useful for you, and am submitting the change as a PR, with a brief description. This is partly selfish, as my design choice was made so that assuming a PR was accepted, implementation of each auth provider would have no impact on the rest of the codebase, therefore making future version upgrades simpler.

This change adds a `plugins` directory, with an `auth` subdirectory. (Who knows what else could be made pluggable.) Inside this directory should be self contained modules, including their own `package.json`/installed `node_modules`. I did this so the plugins themselves are not dependant on OpenKB's own`package.json`, nor do they need to add their dependencies to it.

I then moved a number of database-login related routes into a new `db` plugin in this directory, and added a setting in the config file, `auth_provider` to use this by default. The resulting behaviour in a default installation is the same as it was before, however, additional plugins can now be inserted into this directory and the corresponding setting changed to use a different one.

Plugins themselves are not completely decoupled - they assume the role of express middleware. For auth provider plugins (currently the only type of plugin...), there are three functions that the module is expected to export:

* `route(router)` - called just before the rest of the `index.js` routes are set up, allowing the plugin to insert its own routes to handle things like posting back to whatever login page it provides
* `login(req, res)` - called by the `/login` route in `index.js`. I guess this could have been provided by the plugin but I wanted to retain *some* consistency - (also because there was a lot of stuff referring to `/login` that didn't need refactoring for what I needed to do)
* `logout(req, res)` - called by the `/logout` route in `index.js` after it's cleared all the session data. it should redirect or do whatever else is appropriate

I used this to auto-login users based on some data that my authentication service provided, but I can see this also being useful to integrate LDAP, OAuth2, and even things like HTTP basic auth by the proxy webserver (e.g. Apache)

I welcome any thoughts / comments